### PR TITLE
Update Panel Docs

### DIFF
--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -1,13 +1,132 @@
 # Panel
 
+Panel creates a container with a header that can take collapsible PanelBody components to easily create a user friendly interface for affecting state and attributes within Gutenberg.
+
+### Sub-Components
+
+#### Panel
+
+##### Props
+
+###### className
+
+The class that will be added with `components-panel`. If no className is passed only `components-panel__body` and `is-opened` is used.
+
+- Type: `String`
+- Required: No
+
+###### header
+
+Title of the Panel. Text will be rendered inside an `<h2>` tag.
+
+- Type: `String`
+- Required: No
+
+
+#### PanelBody
+
+The PanelBody creates a collapsible container that can be toggled open or closed. 
+
+
+##### Props
+
+###### title
+
+Title of the PanelBody. This shows even when the PanelBody is closed.
+
+- Type: `String`
+- Required: No
+
+
+###### opened
+
+If opened is true then the Panel will remain open regardless of the initialOpen prop and the panel will be prevented from being closed.
+
+- Type: `Boolean`
+- Required: No
+
+###### className
+
+The class that will be added with `components-panel__body`, if the panel is currently open, the `is-opened` class will also be passed to the classes of the wrapper div. If no className is passed only `components-panel__body` and `is-opened` is used.
+
+- Type: `String`
+- Required: No
+
+###### icon
+
+An icon to be shown next to the PanelBody title
+
+- Type: `String`
+- Required: No
+
+###### onToggle
+
+A function that is called when the user clicks on the PanelBody title after the open state is changed.
+
+- Type: `function`
+- Required: No
+
+###### initialOpen
+
+Whether or not the panel will start open.
+
+- Type: `Boolean`
+- Required: No
+- Default: true
+
+#### PanelRow
+
+The is a generic container for panel content. Default Gutenberg styles add a top margin and arrange items in a flex row.
+
+##### Props
+
+###### className
+
+The class that will be added with `components-panel__row`.  to the classes of the wrapper div. If no className is passed only `components-panel__body` is used.
+
+- Type: `String`
+- Required: No
+
+
 ## Usage
 
+### Standalone
+
 ```jsx
-import { Panel, PanelBody } from '@wordpress/components';
+import { Panel, PanelBody, PanelRow } from '@wordpress/components';
  
 const MyPanel = () => (
 	<Panel header="My Panel">
-		<PanelBody>Panel body</PanelBody>
+		<PanelBody
+			title="My Block Settings"
+			icon="welcome-widgets-menus"
+			initialOpen={true}
+		>
+			<PanelRow>
+				My Panel Inputs and Labels
+			</PanelRow>
+		</PanelBody>
 	</Panel>
+);
+```
+
+
+### Within `InspectorControls`
+
+The InspectorControls component used in a block's edit method is already inside a Panel component provided by Gutenberg, therefore the Panel component should not be used.
+
+```jsx
+import { PanelBody, PanelRow } from '@wordpress/components';
+ 
+const MyPanel = (props) => (
+		<PanelBody
+			title="My Block Settings"
+			icon="welcome-widgets-menus"
+			initialOpen={true}
+		>
+			<PanelRow>
+				My Panel Inputs and Labels
+			</PanelRow>
+		</PanelBody>
 );
 ```

--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -1,6 +1,6 @@
 # Panel
 
-Panel creates a container with a header that can take collapsible PanelBody components to easily create a user friendly interface for affecting state and attributes within Gutenberg.
+The Panel creates a container with a header that can take collapsible PanelBody components to easily create a user friendly interface for affecting state and attributes within Gutenberg.
 
 ### Sub-Components
 
@@ -22,7 +22,7 @@ Title of the Panel. Text will be rendered inside an `<h2>` tag.
 - Type: `String`
 - Required: No
 
-
+---
 #### PanelBody
 
 The PanelBody creates a collapsible container that can be toggled open or closed. 
@@ -73,7 +73,7 @@ Whether or not the panel will start open.
 - Type: `Boolean`
 - Required: No
 - Default: true
-
+---
 #### PanelRow
 
 The is a generic container for panel content. Default Gutenberg styles add a top margin and arrange items in a flex row.
@@ -86,7 +86,20 @@ The class that will be added with `components-panel__row`.  to the classes of th
 
 - Type: `String`
 - Required: No
+---
 
+#### PanelHeader
+
+This is a simple container for a header component. This is used by the `Panel` component under the hood, so it does not typically need to be used.
+
+##### Props
+
+###### label
+
+The text that will be rendered as the title of the Panel. Will be rendered in an `<h2>` tag.
+
+- Type: `String`
+- Required: No
 
 ## Usage
 


### PR DESCRIPTION
## Description
Expands on the existing Panel Documentation with greater information about the props. I was unsure about how much detail to include about using the whole Panel (which is used less often as I understand it) versus using it within the InspectorControls panel, so I included information about both. There is still some possibility of confusion on when to use Panel versus just PanelBody however.

## How has this been tested?
Example components have been tested with a dummy component to ensure they work out of the box

## Types of changes
Just a documentation update to address #9107

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
